### PR TITLE
docs: add tips for calling `createCanvasContext`

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/version-3.x/apis/canvas/createCanvasContext.md
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.x/apis/canvas/createCanvasContext.md
@@ -5,6 +5,9 @@ sidebar_label: createCanvasContext
 
 Creates a [CanvasContext](./CanvasContext.md) object.
 
+**Tip**: The canvasId needs to be specified, the drawing context only works on the corresponding `<canvas/>`; in addition, you need to execute it in the `useReady` callback in the web side, otherwise it will get the CanvasContext before the underlying canvas is rendered, resulting in the underlying context being `undefined` and thus can't draw properly.
+
+
 > [Reference](https://developers.weixin.qq.com/miniprogram/en/dev/api/canvas/wx.createCanvasContext.html)
 
 ## Type

--- a/packages/taro/types/api/canvas/index.d.ts
+++ b/packages/taro/types/api/canvas/index.d.ts
@@ -1730,28 +1730,30 @@ declare module '../../index' {
 
     /** 创建 canvas 的绘图上下文 [CanvasContext](/docs/apis/canvas/CanvasContext) 对象
      *
-     * **Tip**: 需要指定 canvasId，该绘图上下文只作用于对应的 `<canvas/>`
+     * **Tip**: 需要指定 canvasId，该绘图上下文只作用于对应的 `<canvas/>`；另外，Web 端需要在 `useReady` 回调中执行它，否则会因为底层 canvas 渲染出来之前而去获取 CanvasContext，导致其底层的 context 为 `undefined`，从而不能正常绘图。
      * @supported weapp, h5
      * @example
      * ```tsx
-     * const context = Taro.createCanvasContext('canvas')
-     *
-     * context.setStrokeStyle("#00ff00")
-     * context.setLineWidth(5)
-     * context.rect(0, 0, 200, 200)
-     * context.stroke()
-     * context.setStrokeStyle("#ff0000")
-     * context.setLineWidth(2)
-     * context.moveTo(160, 100)
-     * context.arc(100, 100, 60, 0, 2 * Math.PI, true)
-     * context.moveTo(140, 100)
-     * context.arc(100, 100, 40, 0, Math.PI, false)
-     * context.moveTo(85, 80)
-     * context.arc(80, 80, 5, 0, 2 * Math.PI, true)
-     * context.moveTo(125, 80)
-     * context.arc(120, 80, 5, 0, 2 * Math.PI, true)
-     * context.stroke()
-     * context.draw()
+     * import {useReady} from "@tarojs/taro";
+     * useReady(() => {
+     *   const context = Taro.createCanvasContext('canvas')
+     *   context.setStrokeStyle("#00ff00")
+     *   context.setLineWidth(5)
+     *   context.rect(0, 0, 200, 200)
+     *   context.stroke()
+     *   context.setStrokeStyle("#ff0000")
+     *   context.setLineWidth(2)
+     *   context.moveTo(160, 100)
+     *   context.arc(100, 100, 60, 0, 2 * Math.PI, true)
+     *   context.moveTo(140, 100)
+     *   context.arc(100, 100, 40, 0, Math.PI, false)
+     *   context.moveTo(85, 80)
+     *   context.arc(80, 80, 5, 0, 2 * Math.PI, true)
+     *   context.moveTo(125, 80)
+     *   context.arc(120, 80, 5, 0, 2 * Math.PI, true)
+     *   context.stroke()
+     *   context.draw()
+     * })
      * ```
      * @see https://developers.weixin.qq.com/miniprogram/dev/api/canvas/wx.createCanvasContext.html
      */

--- a/versioned_docs/version-3.x/apis/canvas/createCanvasContext.md
+++ b/versioned_docs/version-3.x/apis/canvas/createCanvasContext.md
@@ -5,7 +5,7 @@ sidebar_label: createCanvasContext
 
 创建 canvas 的绘图上下文 [CanvasContext](/docs/apis/canvas/CanvasContext) 对象
 
-**Tip**: 需要指定 canvasId，该绘图上下文只作用于对应的 `<canvas/>`
+**Tip**: 需要指定 canvasId，该绘图上下文只作用于对应的 `<canvas/>`；另外，Web 端需要在 `useReady` 回调中执行它，否则会因为底层 canvas 渲染出来之前而去获取 CanvasContext，导致其底层的 context 为 `undefined`，从而不能正常绘图。
 
 支持情况：<img title="微信小程序" src={require('@site/static/img/platform/weapp.png').default} className="icon_platform" width="25px"/> <img title="H5" src={require('@site/static/img/platform/h5.png').default} className="icon_platform" width="25px"/> <img title="React Native" src={require('@site/static/img/platform/rn.png').default} className="icon_platform icon_platform--not-support" width="25px"/> <img title="Harmony" src={require('@site/static/img/platform/harmony.png').default} className="icon_platform icon_platform--not-support" width="25px"/>
 
@@ -27,22 +27,26 @@ sidebar_label: createCanvasContext
 ## 示例代码
 
 ```tsx
-const context = Taro.createCanvasContext('canvas')
+import {useReady} from "@tarojs/taro";
 
-context.setStrokeStyle("#00ff00")
-context.setLineWidth(5)
-context.rect(0, 0, 200, 200)
-context.stroke()
-context.setStrokeStyle("#ff0000")
-context.setLineWidth(2)
-context.moveTo(160, 100)
-context.arc(100, 100, 60, 0, 2 * Math.PI, true)
-context.moveTo(140, 100)
-context.arc(100, 100, 40, 0, Math.PI, false)
-context.moveTo(85, 80)
-context.arc(80, 80, 5, 0, 2 * Math.PI, true)
-context.moveTo(125, 80)
-context.arc(120, 80, 5, 0, 2 * Math.PI, true)
-context.stroke()
-context.draw()
+useReady(() => {
+  const context = Taro.createCanvasContext('canvas')
+
+  context.setStrokeStyle("#00ff00")
+  context.setLineWidth(5)
+  context.rect(0, 0, 200, 200)
+  context.stroke()
+  context.setStrokeStyle("#ff0000")
+  context.setLineWidth(2)
+  context.moveTo(160, 100)
+  context.arc(100, 100, 60, 0, 2 * Math.PI, true)
+  context.moveTo(140, 100)
+  context.arc(100, 100, 40, 0, Math.PI, false)
+  context.moveTo(85, 80)
+  context.arc(80, 80, 5, 0, 2 * Math.PI, true)
+  context.moveTo(125, 80)
+  context.arc(120, 80, 5, 0, 2 * Math.PI, true)
+  context.stroke()
+  context.draw()
+})
 ```


### PR DESCRIPTION
发现示例代码，在微信小程序端可以工作；在 Web 端异常，报 context.draw 等方法为 undefined。经过排查，在 Web 端需要将 createCanvasContext 放在 useReady 中执行。使用 useReady，即能同时在微信小程序和 Web 端正常工作。