### PR TITLE
docs: env-mode-config.md

### DIFF
--- a/docs/env-mode-config.md
+++ b/docs/env-mode-config.md
@@ -21,8 +21,8 @@ Taro v3.5.10 开始支持，之前的版本可参考 [taro-plugin-environment](h
 假设你有`开发`和`生产`2 个环境，你可以在项目根目录下新建两个`env`环境文件：
 
 ```
-env.development     # 在 development 模式时被载入
-env.production      # 在 production 模式时被载入
+.env.development     # 在 development 模式时被载入
+.env.production      # 在 production 模式时被载入
 ```
 
 环境文件只包含环境变量的“键=值”对：

--- a/versioned_docs/version-3.x/env-mode-config.md
+++ b/versioned_docs/version-3.x/env-mode-config.md
@@ -21,8 +21,8 @@ Taro v3.5.10 开始支持，之前的版本可参考 [taro-plugin-environment](h
 假设你有`开发`和`生产`2 个环境，你可以在项目根目录下新建两个`env`环境文件：
 
 ```
-env.development     # 在 development 模式时被载入
-env.production      # 在 production 模式时被载入
+.env.development     # 在 development 模式时被载入
+.env.production      # 在 production 模式时被载入
 ```
 
 环境文件只包含环境变量的“键=值”对：


### PR DESCRIPTION
**改正环境变量文件命名**
这个 PR 修正了环境变量文件的命名方式，将其规范为 .env.[mode] 的格式。之前的命名方式为 env.[mode]，缺少了前面的 .