### PR TITLE
fix: footer style error

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -161,6 +161,7 @@ a:hover {
 
 .footer {
   position: relative;
+  overflow: hidden;
   z-index: 10;
   border-top: 1px solid rgba(164, 164, 164, 20%);
   height: 500px;


### PR DESCRIPTION
修复了一处由于没有给.footer添加overflow: hidden导致的手机端样式错误（页面宽度>100vw，可以向右滑动）
修复前:
![6 JBO{30KSZRVI HSO4B4`A](https://github.com/NervJS/taro-docs/assets/83355040/4557dd29-e28f-4270-b0dc-086d6ce98fdf)
__导致错误的CSS：__
![image](https://github.com/NervJS/taro-docs/assets/83355040/1927c84e-5aa9-4004-baeb-ec5125de7400)

修复后：
![image](https://github.com/NervJS/taro-docs/assets/83355040/b351a6e4-f6fe-483f-a953-4a3c2cea2a17)
