### PR TITLE
fix: guide navigation links are broken

### DIFF
--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -1622,7 +1622,7 @@ const config = {
 
 #### 使用插件化系统进行拓展
 
-在 [CSS 工具](#CSS 工具) 我们已经使用了名为 `@tarojs/plugin-sass` 的插件来实现对 `Sass` 的支持。比起使用 Webpack 拓展编译，Taro 的插件功能不用在每个端都对 Webpack 进行配置，只用使用插件即可。
+在 [CSS 工具](#CSS-工具) 我们已经使用了名为 `@tarojs/plugin-sass` 的插件来实现对 `Sass` 的支持。比起使用 Webpack 拓展编译，Taro 的插件功能不用在每个端都对 Webpack 进行配置，只用使用插件即可。
 
 除此之外，Taro 的插件化功能还可以拓展 Taro CLI 编译命令，拓展编译流程，拓展编译平台，你可以访问 [插件功能文档](./plugin.md) 了解更多自定义配置的信息。
 

--- a/versioned_docs/version-3.x/guide.mdx
+++ b/versioned_docs/version-3.x/guide.mdx
@@ -1622,7 +1622,7 @@ const config = {
 
 #### 使用插件化系统进行拓展
 
-在 [CSS 工具](#CSS 工具) 我们已经使用了名为 `@tarojs/plugin-sass` 的插件来实现对 `Sass` 的支持。比起使用 Webpack 拓展编译，Taro 的插件功能不用在每个端都对 Webpack 进行配置，只用使用插件即可。
+在 [CSS 工具](#CSS-工具) 我们已经使用了名为 `@tarojs/plugin-sass` 的插件来实现对 `Sass` 的支持。比起使用 Webpack 拓展编译，Taro 的插件功能不用在每个端都对 Webpack 进行配置，只用使用插件即可。
 
 除此之外，Taro 的插件化功能还可以拓展 Taro CLI 编译命令，拓展编译流程，拓展编译平台，你可以访问 [插件功能文档](./plugin.md) 了解更多自定义配置的信息。
 


### PR DESCRIPTION
### Description (*)

<img width="1331" alt="Screen Shot 2023-07-16 at 3 40 06 PM" src="https://github.com/NervJS/taro-docs/assets/37981444/966dffe0-b058-423c-967c-f7f28eb0adb0">

### Change Log

Add hyphen between Chinese words to fix this issue.

### Root Cause

If spaces were allowed in link text, it would be difficult for Markdown parsers to determine where the link text ends and the link URL begins. To avoid these issues, it's recommended to use hyphens (-) or underscores (_) to represent spaces in link text.