### PR TITLE
docs: fix fower docs link 404

### DIFF
--- a/docs/css-in-js.mdx
+++ b/docs/css-in-js.mdx
@@ -149,4 +149,4 @@ export default Index
 
 ## Fower
 
-社区还有另一个方案 **Fower**，[文档](https://fower.vercel.app/zh-cn/docs/use-with-taro)
+社区还有另一个方案 **Fower**，[文档](https://fower.vercel.app/docs/use-with-taro)

--- a/i18n/en/docusaurus-plugin-content-docs/current/css-in-js.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/css-in-js.mdx
@@ -142,4 +142,4 @@ export default Index
 
 ## Fower
 
-The community has another option **Fower**，[Documentation](https://fower.vercel.app/zh-cn/docs/use-with-taro)
+The community has another option **Fower**，[Documentation](https://fower.vercel.app/docs/use-with-taro)

--- a/i18n/en/docusaurus-plugin-content-docs/version-3.x/css-in-js.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/version-3.x/css-in-js.mdx
@@ -142,4 +142,4 @@ export default Index
 
 ## Fower
 
-The community has another option **Fower**，[Documentation](https://fower.vercel.app/zh-cn/docs/use-with-taro)
+The community has another option **Fower**，[Documentation](https://fower.vercel.app/docs/use-with-taro)

--- a/versioned_docs/version-3.x/css-in-js.mdx
+++ b/versioned_docs/version-3.x/css-in-js.mdx
@@ -149,4 +149,4 @@ export default Index
 
 ## Fower
 
-社区还有另一个方案 **Fower**，[文档](https://fower.vercel.app/zh-cn/docs/use-with-taro)
+社区还有另一个方案 **Fower**，[文档](https://fower.vercel.app/docs/use-with-taro)


### PR DESCRIPTION
replace the 404  zh-cn docs url to default language url

see https://github.com/forsigner/fower/issues/49