### PR TITLE
Update tailwindcss.mdx

### DIFF
--- a/docs/tailwindcss.mdx
+++ b/docs/tailwindcss.mdx
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
   <TabItem label="npm" value="npm">
 
 ```bash
-npm i -D tailwindcss postcss autoprefixer
+npm i -D tailwindcss@3 postcss autoprefixer
 # 初始化 tailwind.config.js 文件
 npx tailwindcss init
 ```


### PR DESCRIPTION
目前文档的配置是针对的v3.x 但是现在会默认安装v4 导致后续配置失败