### PR TITLE
fix(docs): correct '脚步语言' to '脚本语言' in optimization guide

### DIFF
--- a/docs/optimized.mdx
+++ b/docs/optimized.mdx
@@ -39,7 +39,7 @@ const config = {
 Taro v3.6.25 开始支持。目前只支持在 Taro React 小程序中使用，暂不支持 Taro Vue，暂不支持在其他端使用。
 :::
 
-借助 **CompileMode**，Taro 可以支持使用各类小程序的视图层脚步语言，如微信小程序的 `wxs`、支付宝小程序的 `sjs`、京东小程序的 `jds`、头条小程序的 `sjs` 等。
+借助 **CompileMode**，Taro 可以支持使用各类小程序的视图层脚本语言，如微信小程序的 `wxs`、支付宝小程序的 `sjs`、京东小程序的 `jds`、头条小程序的 `sjs` 等。
 
 用法：
 


### PR DESCRIPTION
**影响范围**  
修正文档中所有出现「脚步语言」的文本为「脚本语言」文本。
**术语修正依据**  
微信官方文档明确使用「脚本语言」文本。