### PR TITLE
docs: Update navigationStyle compatibility information

### DIFF
--- a/docs/app-config.md
+++ b/docs/app-config.md
@@ -96,7 +96,7 @@ export default {
 | navigationBarBackgroundColor | ✔️                                  | ✔️                         | ✔️       | ✔️     | ✔️  | ✔️  | ✔️          |
 | navigationBarTextStyle       | ✔️                                  | ✔️                         | ✔️       | ✘      | ✔️  | ✔️  | ✔️          |
 | navigationBarTitleText       | ✔️                                  | ✔️                         | ✔️       | ✔️     | ✔️  | ✔️  | ✔️          |
-| navigationStyle              | ✔️（微信客户端 6.6.0）              | ✔️（百度 App 版本 11.1.0） | ✔️       | ✘      | ✘   | ✘   | ✔️          |
+| navigationStyle              | ✔️（微信客户端 6.6.0）              | ✔️（百度 App 版本 11.1.0） | ✔️       | ✘      | ✔️（默认`custom`）   | ✘   | ✔️          |
 | backgroundColor              | ✔️                                  | ✔️                         | ✔️       | ✘      | ✘   | ✘   | ✔️          |
 | backgroundTextStyle          | ✔️                                  | ✔️                         | ✔️       | ✘      | ✘   | ✘   | ✘           |
 | backgroundColorTop           | ✔️（微信客户端 6.5.16）             | ✘                          | ✔️       | ✘      | ✘   | ✘   | ✘           |


### PR DESCRIPTION
https://github.com/NervJS/taro/blob/ee3f700e5d7c071efb9203a23c0364fb2ddb3e96/packages/taro-router/src/router/navigation-bar.ts#L235-L253

h5是支持顶部导航栏的，不过默认不显示，参考上面的代码实现。